### PR TITLE
Fix disposal

### DIFF
--- a/OtelWithSerilogAndSeq/LoggingBuilderExtensions.cs
+++ b/OtelWithSerilogAndSeq/LoggingBuilderExtensions.cs
@@ -12,7 +12,7 @@ public static class LoggingBuilderExtensions
     {
         builder.ClearProviders();
         builder.SetMinimumLevel(LogLevel.Trace);
-        
+
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()
             .Enrich.FromLogContext()
@@ -23,23 +23,22 @@ public static class LoggingBuilderExtensions
             .Enrich.WithProperty(
                 "Application", // TODO: use process.executable.name ?
                 Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty)
-            .WriteTo.Logger(
-                c => c
-                    .Enrich.With<ExceptionMessageEnricher>()
-                    .WriteTo.Console(
-                        LogEventLevel.Information,
-                        "{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}: {Message} {ExceptionMessage} {NewLine}",
-                        theme: AnsiConsoleTheme.Code))
+            .WriteTo.Logger(c => c
+                .Enrich.With<ExceptionMessageEnricher>()
+                .WriteTo.Console(
+                    LogEventLevel.Information,
+                    "{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}: {Message} {ExceptionMessage} {NewLine}",
+                    theme: AnsiConsoleTheme.Code))
             .CreateLogger();
-        
+
         // from https://github.com/serilog-tracing/serilog-tracing?tab=readme-ov-file#enabling-tracing-with-activitylistenerconfigurationtracetosharedlogger
-        // TODO: TraceToSharedLogger returns an IDisposable, if we dispose it here, tracing does not work.
-        //       Do we need to dispose it? How? 
+        // TODO: TraceToSharedLogger returns an IDisposable, it must not be disposed before the app terminates,
+        // because then tracing would not work anymore. How can we properly dispose it? 
         _ = new ActivityListenerConfiguration()
             .TraceToSharedLogger();
-        
-        builder.AddSerilog();
-        
+
+        builder.AddSerilog(dispose: true);
+
         return builder;
     }
 }

--- a/OtelWithSerilogAndSeq/OtelWithSerilogAndSeq.csproj
+++ b/OtelWithSerilogAndSeq/OtelWithSerilogAndSeq.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1"/>
-        <PackageReference Include="Serilog" Version="4.0.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-        <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
-        <PackageReference Include="SerilogTracing.Expressions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4"/>
+        <PackageReference Include="Serilog" Version="4.2.0"/>
+        <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
+        <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0"/>
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
+        <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0"/>
+        <PackageReference Include="SerilogTracing.Expressions" Version="2.3.1"/>
     </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ as demonstrated here https://github.com/serilog-tracing/serilog-tracing
 
 The main difference here is that Serilog is not used for logging and tracing but instead the `Microsoft.Extensions.Logging` 
 abstraction and `System.Diagnostics.ActivitySource` are used.
-Serilog is merely used for the sinks.
 
-In Seq the traces and spans do not show up:
-
-![Seq Screenshot without traces and spans](seq-screenshot.png)
+The idea is that a framework or library that does the actual logging does not need a dependency to Serilog or Seq.
+Only at the application level the user would add Serilog and Seq as a sink.


### PR DESCRIPTION
Because serilog was not properly disposed, the logs did not contain the shutdown messages of the application.